### PR TITLE
Remove higher-path-precedence Node v10 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM circleci/ruby:2.6.3-node-browsers-legacy
 # Install qt 4.8.X (for capybara-webkit gem) and also
 # postgresql-client and mysql-client for databases
 # and node/yarn for Webpacker
-RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
+  && curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
   && sudo apt-get update \
   && sudo apt-get install -y \
     gcc g++ make \
@@ -18,5 +18,8 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
     yarn \
     phantomjs \
   && sudo rm -rf /var/lib/apt/lists/*
+
+# the base image comes with an older version of Node that takes precedence given the path
+RUN sudo rm /usr/local/bin/node
 
 WORKDIR /home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM circleci/ruby:2.6.3-node-browsers-legacy
 # Install qt 4.8.X (for capybara-webkit gem) and also
 # postgresql-client and mysql-client for databases
 # and node/yarn for Webpacker
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
-  && curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
   && sudo apt-get update \
   && sudo apt-get install -y \
     gcc g++ make \


### PR DESCRIPTION
https://github.com/eSpark/core/pull/4205 introduces Jest testing to Core, but the specs were failing because of [a NodeJS version issue](https://github.com/jsdom/jsdom/issues/2795). It turns out that while we install Node 12 properly, the underlying Circle CI Docker image has a copy of Node 10 that has higher priority in the path. 

This PR removes that binary so Jest will use Node 12 as expected.