### PR TITLE
Ruby 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM circleci/ruby:2.6.6-node-browsers-legacy
+FROM cimg/ruby:2.7-browsers
 
-# Install qt 4.8.X (for capybara-webkit gem) and also
-# postgresql-client and mysql-client for databases
+# Install mysql-client for databases
 # and node/yarn for Webpacker
 RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get update \
   && sudo apt-get install -y \
-    gcc g++ make \
-    qt4-default libqtwebkit4 \
-    ruby-dev zlib1g-dev \
-    postgresql-client \
     default-mysql-client \
     ffmpeg \
     nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.7-browsers
+FROM cimg/ruby:3.0-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker


### PR DESCRIPTION
- use cimg 2.7 as base, trim some deps we probably do not need anymore
- ruby 3.0
