### PR TITLE
Ruby 3.2.0 CI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM cimg/ruby:3.1.3-browsers
 RUN sudo rm /usr/local/bin/node \
   && curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && sudo apt-get install -y \
+    google-chrome-stable \
     nodejs \
     default-mysql-client \
   && sudo rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM cimg/ruby:3.1-browsers
+FROM cimg/ruby:3.1.3-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker
-RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN sudo rm /usr/local/bin/node \
     google-chrome-stable \
     nodejs \
     default-mysql-client \
-  && sudo rm -rf /var/lib/apt/lists/*
+  && sudo rm -rf /var/lib/apt/lists/* \
+  && wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+  && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+  && sudo mv phantomjs-2.1.1-linux-x86_64 /usr/local/share \
+  && sudo ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
 
 WORKDIR /home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM circleci/ruby:2.6.6-node-browsers-legacy
+FROM cimg/ruby:2.7-browsers
 
-# Install qt 4.8.X (for capybara-webkit gem) and also
-# postgresql-client and mysql-client for databases
+# Install mysql-client for databases
 # and node/yarn for Webpacker
 RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo bash - \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
   && sudo apt-get update \
   && sudo apt-get install -y \
-    gcc g++ make \
-    qt4-default libqtwebkit4 \
-    ruby-dev zlib1g-dev \
-    postgresql-client \
     default-mysql-client \
     ffmpeg \
     nodejs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,4 @@ RUN sudo apt-get update \
     default-mysql-client \
   && sudo rm -rf /var/lib/apt/lists/*
 
-# the base image comes with an older version of Node that takes precedence given the path
-RUN sudo rm /usr/local/bin/node
-
 WORKDIR /home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.1.3-browsers
+FROM cimg/ruby:3.2.0-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,9 @@ FROM cimg/ruby:3.1.3-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker
-RUN curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
-  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
-  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
-  && sudo apt-get update \
+RUN sudo apt-get update \
   && sudo apt-get install -y \
     default-mysql-client \
-    ffmpeg \
-    nodejs \
-    yarn \
-    phantomjs \
   && sudo rm -rf /var/lib/apt/lists/*
 
 # the base image comes with an older version of Node that takes precedence given the path

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN sudo rm /usr/local/bin/node \
   && sudo apt-get install -y \
     google-chrome-stable \
     default-mysql-client \
+    nodejs \
   && sudo rm -rf /var/lib/apt/lists/* \
   # install phantomjs
   && wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN sudo rm /usr/local/bin/node \
   && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
   && sudo mv phantomjs-2.1.1-linux-x86_64 /usr/local/share \
   && sudo ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin \
-  && rm -r bin
+  && rm phantomjs-2.1.1-linux-x86_64.tar.bz2
 
 WORKDIR /home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ RUN sudo rm /usr/local/bin/node \
   && curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && sudo apt-get install -y \
     google-chrome-stable \
-    nodejs \
     default-mysql-client \
   && sudo rm -rf /var/lib/apt/lists/* \
+  # install phantomjs
   && wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
   && tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 \
   && sudo mv phantomjs-2.1.1-linux-x86_64 /usr/local/share \
-  && sudo ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin
+  && sudo ln -sf /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin \
+  && rm -r bin
 
 WORKDIR /home/circleci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.7-browsers
+FROM cimg/ruby:3.0-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM cimg/ruby:3.1.3-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker
-RUN sudo apt-get update \
+RUN sudo rm /usr/local/bin/node \
+  && curl -sL https://deb.nodesource.com/setup_16.x | sudo bash - \
   && sudo apt-get install -y \
+    nodejs \
     default-mysql-client \
   && sudo rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.0-browsers
+FROM cimg/ruby:3.1-browsers
 
 # Install mysql-client for databases
 # and node/yarn for Webpacker


### PR DESCRIPTION
- use cimg 2.7 as base, trim some deps we probably do not need anymore
- ruby 3.0
- bump base image version
- install node16, from circle 3.1.3 image
- remove packages
- do no remove local node
- remove existing node, install 16.x
- preinstall chrome
- install phantomjs
- node already installed, install phantomjs
- delete archive, do not need to delete bin
- nodejs actually not already installed...
- 3.2.0
